### PR TITLE
chore: Configure Super-Linter for Bash and Markdown only and clean up bash functions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v3
         env:
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_BASH: true
+          VALIDATE_MARKDOWN: true
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bash/aliases/behave-like-linux
+++ b/bash/aliases/behave-like-linux
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 alias dos2unix="perl -pi -e 's/\r\n|\n|\r/\n/g'"
 alias unix2dos="perl -pi -e 's/\r\n|\n|\r/\r\n/g'"
 

--- a/bash/aliases/dev-helpers
+++ b/bash/aliases/dev-helpers
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 alias myip="ifconfig en0 | grep 'inet ' | cut -f2 -d ' '"
 
 alias yarnls="yarn list --depth=0"

--- a/bash/aliases/index.sh
+++ b/bash/aliases/index.sh
@@ -1,11 +1,10 @@
-BASENAME=$(basename $BASH_SOURCE)
-DIRNAME=$(dirname $BASH_SOURCE)
-. ${DIRNAME}/../lib/core.sh
+# shellcheck shell=bash
 
-[[ $0 == $BASH_SOURCE ]] && only_sourcing_allowed
+INVOCATION_SOURCE=${BASH_SOURCE[0]}
+DIRNAME=$(dirname "${INVOCATION_SOURCE}")
 
-# Set up aliases
-for alias_script in $(find ${DIRNAME} -type f ! -name ${BASENAME} ! -name "README.md")
-do
-    source ${alias_script}
-done
+# shellcheck source=/bash/lib/core.sh
+source "${DIRNAME}/../lib/core.sh"
+(return 0 2>/dev/null) || only_sourcing_allowed
+
+source_collection "${INVOCATION_SOURCE}"

--- a/bash/aliases/ls
+++ b/bash/aliases/ls
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 # Colorize output.
 alias ls='ls -G'
 
@@ -10,5 +12,6 @@ alias ll='ls -l'
 # List hidden files only.  Ripped straight from RedHat.
 alias l.='ls -d .*'
 
+# shellcheck disable=SC2142
 # List printers.
 alias lsp="lpstat -p | awk \"{print \\\$2}\""

--- a/bash/aliases/typos
+++ b/bash/aliases/typos
@@ -1,2 +1,4 @@
+# shellcheck shell=bash
+
 alias gti='git'
 alias pdw='pwd'

--- a/bash/functions/docker-cli
+++ b/bash/functions/docker-cli
@@ -1,17 +1,19 @@
+# shellcheck shell=bash
+
 docker-cli ()
 {
     EXIT_FAILURE=1
 
-    [[ -z "$1" ]] && echo "USAGE: docker-cli <container_name>" && return ${EXIT_FAILURE}
+    [[ -z "$1" ]] && echo "USAGE: docker-cli <container_name>" && return "${EXIT_FAILURE}"
 
-    container_id=$(docker ps -q -f name=$1)
+    container_id=$(docker ps -q -f name="$1")
 
-    if [[ -z "$container_id" ]]
+    if [[ -z "${container_id}" ]]
     then
         echo "ERROR: Docker container $1 not found"
-        return ${EXIT_FAILURE}
+        return "${EXIT_FAILURE}"
     else
         echo "Attaching to Docker container $1 with command: docker exec -it ${container_id} /bin/bash"
-        docker exec -it ${container_id} /bin/bash
+        docker exec -it "${container_id}" /bin/bash
     fi
 }

--- a/bash/functions/git-add-modified
+++ b/bash/functions/git-add-modified
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 git-add-modified()
 {
     git status | grep modified | awk '{printf("%s%c", $2, 0)}' | xargs -0 git add

--- a/bash/functions/git-set-upstream-branch
+++ b/bash/functions/git-set-upstream-branch
@@ -1,9 +1,11 @@
+# shellcheck shell=bash
+
 git-set-upstream-branch()
 {
     # Newer versions of Git support a --show-current switch for "branch" that
     # will simplify the command below
     #   https://git-scm.com/docs/git-branch#Documentation/git-branch.txt---show-current
-    current_branch=$(git branch | grep '^*' | cut -f2 -d'*' | sed 's/^[[:blank:]]*//;s/[[:blank:]]*$//')
+    current_branch=$(git branch | grep '^\*' | cut -f2 -d'*' | sed 's/^[[:blank:]]*//;s/[[:blank:]]*$//')
 
-    git branch --set-upstream-to=origin/$current_branch $current_branch
+    git branch --set-upstream-to=origin/"${current_branch}" "${current_branch}"
 }

--- a/bash/functions/index.sh
+++ b/bash/functions/index.sh
@@ -1,11 +1,10 @@
-BASENAME=$(basename $BASH_SOURCE)
-DIRNAME=$(dirname $BASH_SOURCE)
-. ${DIRNAME}/../lib/core.sh
+# shellcheck shell=bash
 
-[[ $0 == $BASH_SOURCE ]] && only_sourcing_allowed
+INVOCATION_SOURCE=${BASH_SOURCE[0]}
+DIRNAME=$(dirname "${INVOCATION_SOURCE}")
 
-# Set up functions
-for function_script in $(find ${DIRNAME} -type f ! -name ${BASENAME} ! -name "README.md")
-do
-    source ${function_script}
-done
+# shellcheck source=/bash/lib/core.sh
+source "${DIRNAME}/../lib/core.sh"
+(return 0 2>/dev/null) || only_sourcing_allowed
+
+source_collection "${INVOCATION_SOURCE}"

--- a/bash/functions/slugify
+++ b/bash/functions/slugify
@@ -1,5 +1,8 @@
-# Compliments of https://gist.github.com/oneohthree/f528c7ae1e701ad990e6
+# shellcheck shell=bash
+
+# Compliments of https://gist.github.com/oneohthree/f528c7ae1e701ad990e6,
+# with slight modification
 slugify ()
 {
-    echo "$@" | iconv -t ascii//TRANSLIT | sed -E s/[^a-zA-Z0-9]+/-/g | sed -E s/^-+\|-+$//g | tr A-Z a-z
+    echo "$@" | iconv -t ascii//TRANSLIT | sed -E s/[^a-zA-Z0-9]+/-/g | sed -E s/^-+\|-+$//g | tr '[:upper:]' '[:lower:]'
 }

--- a/bash/functions/tac
+++ b/bash/functions/tac
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 tac()
 {
     INPUT=${1:-/dev/stdin}

--- a/bash/functions/vmstat
+++ b/bash/functions/vmstat
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 # Use in conjunction with alias free="vm_stat | vm_stat_format"
 # Source: https://apple.stackexchange.com/a/94258
 vm_stat_format()

--- a/bash/index.sh
+++ b/bash/index.sh
@@ -1,20 +1,24 @@
+# shellcheck shell=bash
+
 source_index ()
 {
   SOURCE_ROOT=$1
 
-  if [[ -e ${SOURCE_ROOT} ]] && [[ -d ${SOURCE_ROOT} ]] && [[ -f ${SOURCE_ROOT}/index.sh ]]
+  if [[ -e "${SOURCE_ROOT}" ]] && [[ -d "${SOURCE_ROOT}" ]] && [[ -f "${SOURCE_ROOT}/index.sh" ]]
   then
-      source ${SOURCE_ROOT}/index.sh
+      # shellcheck source=/bash/index.sh
+      source "${SOURCE_ROOT}/index.sh"
   fi
 }
 
-SCRIPTS_ROOT=$(dirname $BASH_SOURCE)
-source ${SCRIPTS_ROOT}/lib/core.sh
+SCRIPTS_ROOT=$(dirname "${BASH_SOURCE[0]}")
+# shellcheck source=/bash/lib/core.sh
+source "${SCRIPTS_ROOT}/lib/core.sh"
 
-[[ $0 == $BASH_SOURCE ]] && only_sourcing_allowed
+(return 0 2>/dev/null) || only_sourcing_allowed
 
-ALIASES_ROOT=${SCRIPTS_ROOT}/aliases
-FUNCTIONS_ROOT=${SCRIPTS_ROOT}/functions
+ALIASES_ROOT="${SCRIPTS_ROOT}/aliases"
+FUNCTIONS_ROOT="${SCRIPTS_ROOT}/functions"
 
-source_index ${ALIASES_ROOT}
-source_index ${FUNCTIONS_ROOT}
+source_index "${ALIASES_ROOT}"
+source_index "${FUNCTIONS_ROOT}"

--- a/bash/lib/core.sh
+++ b/bash/lib/core.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 no_direct_invocation_message ()
 {
   echo "This script can only be sourced, e.g. . $0, or source $0"
@@ -7,4 +9,17 @@ only_sourcing_allowed ()
 {
   no_direct_invocation_message
   exit 1
+}
+
+source_collection ()
+{
+  SOURCE="$1"
+  BASENAME=$(basename "${SOURCE}")
+  DIRNAME=$(dirname "${SOURCE}")
+
+  while IFS= read -r -d '' script
+  do
+    # shellcheck disable=SC1090
+    source "${script}"
+  done < <(find "${DIRNAME}" -type f \! -name "${BASENAME}" \! -name "README.md" -print0)
 }


### PR DESCRIPTION
This configures the Super-Linter action to check shell (Bash) and Markdown files only.  Existing Bash functions have been cleaned up to satisfy Shellcheck.