### PR TITLE
feat: Handle multiple container matches for docker-cli

### DIFF
--- a/shell/functions/docker-cli
+++ b/shell/functions/docker-cli
@@ -6,14 +6,39 @@ docker-cli ()
 
     [[ -z "$1" ]] && echo "USAGE: docker-cli <container_name>" && return "${EXIT_FAILURE}"
 
-    container_id=$(docker ps -q -f name="$1")
+    container_id_list=$(docker ps -q -f name="$1")
+    container_count=$(wc -w <<< $container_id_list)
 
-    if [[ -z "${container_id}" ]]
+    if [[ $(wc -w <<< $container_id_list) -eq 0 ]]
     then
         echo "ERROR: Docker container $1 not found"
         return "${EXIT_FAILURE}"
     else
-        echo "Attaching to Docker container $1 with command: docker exec -it ${container_id} /bin/bash"
+        # Check if more than one match was returned
+        if [[ $(wc -w <<< $container_id_list) -eq 1 ]]
+        then
+            container_id=${container_id_list}
+        else
+            echo -e "Multiple matches were found.\n"
+            docker ps -f name="$1" --format "table {{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Ports}}"
+            echo
+            PS3="Enter your selection ($(seq $(bc <<< $(wc -w <<< $cl)+1) | paste -s -d ',' /dev/stdin)) > "
+
+            select opt in $container_id_list quit
+            do
+                case $opt in
+                    quit)
+                        return 0
+                        ;;
+                    *)
+                        container_id=${opt}
+                        break
+                esac
+            done
+        fi
+
+        container_name=$(docker ps -f id=${container_id} --format "{{.Names}}")
+        echo "Attaching to Docker container ${container_name} with command: docker exec -it ${container_id} /bin/bash"
         docker exec -it "${container_id}" /bin/bash
     fi
 }


### PR DESCRIPTION
This enables `docker-cli` to support multiple matches for an image name.

_WIP!_

```
$ docker-cli my-container-name
Multiple matches were found.

CONTAINER ID   NAMES             IMAGE                  PORTS
12345678abcd   super-bash-app    super-bash-app:0.0.1   0.0.0.0:8080->8080/tcp
90abcdef1234   super-bash-db     mysql:8.0              0.0.0.0:3306->3306/tcp, 33060/tcp

1) 12345678abcd
2) 90abcdef1234
3) quit
Enter your selection (1,2,3) > 1
Attaching to Docker container super-bash-app with command: docker exec -it 12345678abcd /bin/bash
```