### PR TITLE
feat: allow docker-cli to use period as shorthand for current working directory

### DIFF
--- a/shell/functions/docker-cli
+++ b/shell/functions/docker-cli
@@ -6,12 +6,19 @@ docker-cli ()
 
     [[ -z "$1" ]] && echo "USAGE: docker-cli <container_name>" && return "${EXIT_FAILURE}"
 
-    container_id_list=$(docker ps -q -f name="$1")
+    if [[ "${1}" == "." ]]
+    then
+      target=$(basename $PWD)
+    else
+      target="${1}"
+    fi
+
+    container_id_list=$(docker ps -q -f name="${target}")
     container_count=$(wc -w <<< $container_id_list)
 
     if [[ $(wc -w <<< $container_id_list) -eq 0 ]]
     then
-        echo "ERROR: Docker container $1 not found"
+        echo "ERROR: Docker container ${target} not found"
         return "${EXIT_FAILURE}"
     else
         # Check if more than one match was returned


### PR DESCRIPTION
This enables `docker-cli` to use `.` in place of basename for current working directory.

#### Usage
`docker-cli` expects a single argument, which is the name of the repo (or a subset of the name since `docker ps` is used under the hood for searching).
If working in a repo `somebody-likes-to-type-who-named-this-repo`, a bash shell in the container can be started up using:

```shell
docker-cli somebody-likes-to-type-who-named-this-repo
```

When the directory name of one's current working directory (not the full or absolute path) matches the name of the repo, a `.` can be used instead.  Shorthand for the above command would be:

```shell
docker-cli .
```